### PR TITLE
Switch to pinned version of reusable workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -73,7 +73,7 @@ jobs:
   deploy-image:
     name: Deploy to environment
     needs: [ set-env ]
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@main
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v1.1.0
     with:
       docker-image-name: 'identapi-app'
       docker-build-file-name: 'docker/Dockerfile'


### PR DESCRIPTION
The `main` branch contains alpha features that are not compatible with this repo so we should pin it to a working stable build