### PR TITLE
Annotate App Insights for each deployment release

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -78,6 +78,7 @@ jobs:
       docker-image-name: 'identapi-app'
       docker-build-file-name: 'docker/Dockerfile'
       environment: ${{ needs.set-env.outputs.environment }}
+      annotate-release: ${{ needs.set-env.outputs.environment == 'development' }}
     secrets:
       azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}
       azure-acr-name: ${{ secrets.ACR_NAME }}


### PR DESCRIPTION
This is currently limited to Dev for testing.

This change adds an extra step post-deployment to record a custom deployment event in App Insights with the SHA that corresponds with the release. This is useful so we can review performance metrics before and after a release